### PR TITLE
Add relative source path

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,10 @@ gulp.src(['src/test.js', 'src/testdir/test2.js'], { base: 'src' })
       .pipe(sourcemaps.init())
         .pipe(plugin1())
         .pipe(plugin2())
-      .pipe(sourcemaps.write({relativeToSourcePath: 'dist/build'}))
+      .pipe(sourcemaps.write('.', {
+        includeContent: false,
+        relativeToSourcePath: 'dist/build'
+      }))
       .pipe(gulp.dest('dist/build'));
   });
   ```

--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ module.exports.write = function write(destPath, options) {
     sourceMap.file = unixStylePath(file.relative);
     sourceMap.sources = sourceMap.sources.map(function(filePath) {
       // calculate the file path relative to the source path
-      if (options.relativeToSourcePath !== undefined) {
+      if (destPath && options.relativeToSourcePath !== undefined) {
         var inputFileFullPath = path.join(file.base, filePath);
         var outputFileFullPath = path.dirname(path.join(process.cwd(), options.relativeToSourcePath, destPath, file.relative));
         filePath = path.relative(outputFileFullPath, inputFileFullPath);

--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ module.exports.write = function write(destPath, options) {
       // calculate the file path relative to the source path
       if (options.relativeToSourcePath !== undefined) {
         var inputFileFullPath = path.join(file.base, filePath);
-        var outputFileFullPath = path.dirname(path.join(process.cwd(), options.relativeToSourcePath, file.relative));
+        var outputFileFullPath = path.dirname(path.join(process.cwd(), options.relativeToSourcePath, destPath, file.relative));
         filePath = path.relative(outputFileFullPath, inputFileFullPath);
       }
 


### PR DESCRIPTION
Hello @sixinli 

I've noticed what I think is an error in how you construct `outputFileFullPath`. `destPath` has to be added to the path in order for it to be correct.

I have also corrected the example in the `README` and checked that `destPath` exists before calculating the file path. 

What I haven't done is adapting the test case - the tests currently don't pass. Could you do that?
